### PR TITLE
feat: add basic enemies with simple spawning logic

### DIFF
--- a/levels/enemy_spawner.gd
+++ b/levels/enemy_spawner.gd
@@ -1,0 +1,21 @@
+extends Marker2D
+
+@onready var timer = $Timer
+
+@export var Enemy : PackedScene
+
+var spawning_enabled : bool = true
+
+
+func _ready():
+	Enemy = load("res://units/enemy.tscn")
+	
+
+func _on_spawn_interval_timeout():
+	spawning_enabled = !spawning_enabled
+
+
+func _on_spawn_frequency_timeout():
+	if not spawning_enabled:
+		var e = Enemy.instantiate()
+		add_child(e)

--- a/levels/game.tscn
+++ b/levels/game.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://in3bw4g4x4qf"]
+[gd_scene load_steps=5 format=3 uid="uid://in3bw4g4x4qf"]
 
 [ext_resource type="Texture2D" uid="uid://nhxwf3d1sq8j" path="res://levels/bg-startscape.png" id="1_71ld3"]
 [ext_resource type="PackedScene" uid="uid://boqgfm75souot" path="res://units/player.tscn" id="1_q8yxs"]
 [ext_resource type="Script" path="res://levels/parallax_background.gd" id="3_g80ly"]
+[ext_resource type="PackedScene" uid="uid://7n27h4530vhv" path="res://units/enemy_spawner.tscn" id="4_utuet"]
 
 [node name="Game" type="Node2D"]
 position = Vector2(0, 3)
@@ -22,3 +23,9 @@ scale = Vector2(0.685054, 0.716737)
 texture = ExtResource("1_71ld3")
 region_enabled = true
 region_rect = Rect2(0, 0, 10000, 1000)
+
+[node name="EnemySpawner" parent="." instance=ExtResource("4_utuet")]
+position = Vector2(1195, 167)
+
+[node name="EnemySpawner2" parent="." instance=ExtResource("4_utuet")]
+position = Vector2(1301, 568)

--- a/units/enemy.gd
+++ b/units/enemy.gd
@@ -1,0 +1,8 @@
+extends Node2D
+
+
+const SPEED = 150
+
+
+func _physics_process(delta):
+	position -= transform.x * SPEED * delta

--- a/units/enemy.tscn
+++ b/units/enemy.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=3 uid="uid://4fjgeuv7aun7"]
+
+[ext_resource type="Script" path="res://units/enemy.gd" id="1_6h8a0"]
+[ext_resource type="Texture2D" uid="uid://dqkvsqmwue64p" path="res://units/PNG_Parts&Spriter_Animation/Ship1/Ship1.png" id="1_ndkjl"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_mvxux"]
+size = Vector2(53, 26)
+
+[node name="Enemy" type="Node2D"]
+script = ExtResource("1_6h8a0")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("1_ndkjl")
+
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+position = Vector2(0.5, -1)
+shape = SubResource("RectangleShape2D_mvxux")

--- a/units/enemy_spawner.tscn
+++ b/units/enemy_spawner.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=3 uid="uid://7n27h4530vhv"]
+
+[ext_resource type="Script" path="res://levels/enemy_spawner.gd" id="1_irjp5"]
+[ext_resource type="Texture2D" uid="uid://bahkf6s6jekvb" path="res://units/PNG_Animations/Shots/Shot5/shot5_exp7.png" id="2_kmkb4"]
+
+[node name="EnemySpawner" type="Marker2D"]
+script = ExtResource("1_irjp5")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(-14, 0)
+texture = ExtResource("2_kmkb4")
+
+[node name="SpawnInterval" type="Timer" parent="."]
+wait_time = 3.0
+autostart = true
+
+[node name="SpawnFrequency" type="Timer" parent="."]
+autostart = true
+
+[connection signal="timeout" from="SpawnInterval" to="." method="_on_spawn_interval_timeout"]
+[connection signal="timeout" from="SpawnFrequency" to="." method="_on_spawn_frequency_timeout"]


### PR DESCRIPTION
Adds Scenes:

- Enemy
    - moves at constant speed when spawned
- EnemySpawner
    - spawns enemies based on frequency, when
    - spawning enabled which is periodic also

- Adds two spawners to the main game scene (see them offset to the right with the yellow sprites)
<img width="770" alt="Screenshot 2024-08-17 at 1 50 03 PM" src="https://github.com/user-attachments/assets/a74e42d1-69ef-42b2-a45b-88aa0475804b">
